### PR TITLE
Some API changes.

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -3723,10 +3723,18 @@ $(function () {
 
   // API
   window.MPP = {
-    press: press,
-    release: release,
-    pressSustain: pressSustain,
-    releaseSustain: releaseSustain,
+    get press() { return press },
+    set press(func) { press = func },
+
+    get release() { return release },
+    set release(func) { release = func },
+
+    get pressSustain() { return pressSustain },
+    set pressSustain(func) { pressSustain = func },
+    
+    get releaseSustain() { return releaseSustain },
+    set releaseSustain(func) { releaseSustain = func },
+
     piano: gPiano,
     client: gClient,
     chat: chat,


### PR DESCRIPTION
Changes made:
You can now set `MPP.press` to whatever you like, and see the effects of your changes, as well with `release`, `pressSustain`, and `releaseSustain`.

Example:
To disable ability to play: `MPP.press = () => { return; }`.