### PR TITLE
Match all urls in message

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -3096,7 +3096,7 @@ $(function () {
       "(?::\\d{2,5})?" +
       // resource path (optional)
       "(?:[/?#]\\S*)?",
-      "i"
+      "ig"
     );
 
     gClient.on("ch", function (msg) {


### PR DESCRIPTION
Fixes a bug where only one url in a message would be an actual link.