### PR TITLE
Fix crown overlapped by nametag

### DIFF
--- a/client/screen.css
+++ b/client/screen.css
@@ -1331,6 +1331,14 @@ input[type="range"]:hover {
     z-index: 300;
 }
 
+#names .nametag {
+    z-index: 301;
+}
+
+#names .name.owner:before {
+    z-index: 302;
+}
+
 #piano {
     z-index: 400;
 }


### PR DESCRIPTION
This PR changes the z-index of the crown so it appears above the name tag.

Before: ![image](https://user-images.githubusercontent.com/28523197/183572282-16929584-4554-4b2d-be3f-b84ff5042ad9.png)
After: ![image](https://user-images.githubusercontent.com/28523197/183573094-838f9e2e-8f12-4983-9222-5968d35a062e.png)