### PR TITLE
Markdown

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -202,6 +202,7 @@
   <script src="/lame.min.js"></script>
   <script src="/Color.js"></script>
   <!--<script src="/ebsprite.js"></script>-->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="/script.js"></script>
 </body>
 

--- a/client/script.js
+++ b/client/script.js
@@ -1,4 +1,3 @@
-
 // 钢琴
 
 $(function () {
@@ -6,17 +5,39 @@ $(function () {
   console.log("%cWelcome to MPP's developer console!", "color:blue; font-size:20px;");
   console.log("%cCheck out the source code: https://github.com/LapisHusky/mppclone/tree/main/client\nGuide for coders and bot developers: https://docs.google.com/document/d/1OrxwdLD1l1TE8iau6ToETVmnLuLXyGBhA0VfAY1Lf14/edit?usp=sharing", "color:gray; font-size:12px;")
 
+  const loadScript = function (url) {
+    return new Promise(function (resolve, reject) {
+      const script = document.createElement('script');
+        script.src = url;
 
-  var renderer = new marked.Renderer();
-  renderer.link = function(href, title, text) {
-  var link = marked.Renderer.prototype.link.apply(this, arguments);
-    return link.replace("<a","<a target='_blank'");
+        script.addEventListener('load', function () {
+            // The script is loaded completely
+            resolve(true);
+        });
+
+        document.head.appendChild(script);
+    });
   };
-    
-  marked.setOptions({
-    renderer: renderer
-  });
-
+  
+  function setupMarkdown() {
+    var renderer = new marked.Renderer();
+    renderer.link = function(href, title, text) {
+      var link = marked.Renderer.prototype.link.apply(this, arguments);
+      return link.replace("<a","<a target='_blank'");
+    };
+   
+    marked.setOptions({
+      renderer: renderer
+    });
+  }
+  
+  if (!window.marked) {
+    loadScript("https://cdn.jsdelivr.net/npm/marked/marked.min.js").then(() => {
+      setupMarkdown();
+    });
+  } else {
+      setupMarkdown();
+  }
 
   var test_mode = (window.location.hash && window.location.hash.match(/^(?:#.+)*#test(?:#.+)*$/i));
 

--- a/client/script.js
+++ b/client/script.js
@@ -7,7 +7,15 @@ $(function () {
   console.log("%cCheck out the source code: https://github.com/LapisHusky/mppclone/tree/main/client\nGuide for coders and bot developers: https://docs.google.com/document/d/1OrxwdLD1l1TE8iau6ToETVmnLuLXyGBhA0VfAY1Lf14/edit?usp=sharing", "color:gray; font-size:12px;")
 
 
-
+  var renderer = new marked.Renderer();
+  renderer.link = function(href, title, text) {
+  var link = marked.Renderer.prototype.link.apply(this, arguments);
+    return link.replace("<a","<a target='_blank'");
+  };
+    
+  marked.setOptions({
+    renderer: renderer
+  });
 
 
   var test_mode = (window.location.hash && window.location.hash.match(/^(?:#.+)*#test(?:#.+)*$/i));
@@ -3058,47 +3066,6 @@ $(function () {
   ////////////////////////////////////////////////////////////////
 
   var chat = (function () {
-    var url_regex = new RegExp(
-      // protocol identifier (optional)
-      // short syntax // still required
-      "(?:(?:(?:https?|ftp):)?\\/\\/)" +
-      // user:pass BasicAuth (optional)
-      "(?:\\S+(?::\\S*)?@)?" +
-      "(?:" +
-      // IP address exclusion
-      // private & local networks
-      "(?!(?:10|127)(?:\\.\\d{1,3}){3})" +
-      "(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})" +
-      "(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})" +
-      // IP address dotted notation octets
-      // excludes loopback network 0.0.0.0
-      // excludes reserved space >= 224.0.0.0
-      // excludes network & broadcast addresses
-      // (first & last IP address of each class)
-      "(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])" +
-      "(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}" +
-      "(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))" +
-      "|" +
-      // host & domain names, may end with dot
-      // can be replaced by a shortest alternative
-      // (?![-_])(?:[-\\w\\u00a1-\\uffff]{0,63}[^-_]\\.)+
-      "(?:" +
-      "(?:" +
-      "[a-z0-9\\u00a1-\\uffff]" +
-      "[a-z0-9\\u00a1-\\uffff_-]{0,62}" +
-      ")?" +
-      "[a-z0-9\\u00a1-\\uffff]\\." +
-      ")+" +
-      // TLD identifier name, may end with dot
-      "(?:[a-z\\u00a1-\\uffff]{2,}\\.?)" +
-      ")" +
-      // port number (optional)
-      "(?::\\d{2,5})?" +
-      // resource path (optional)
-      "(?:[/?#]\\S*)?",
-      "ig"
-    );
-
     gClient.on("ch", function (msg) {
       if (msg.ch.settings.chat) {
         chat.show();
@@ -3324,14 +3291,8 @@ $(function () {
           else return match;
         });
 
-        // link formatting
-        message = message.replace(url_regex, match => {
-          var safe = $("<div>").text(match).html();
-          return `<a rel="noreferer noopener" target="_blank" class="chatLink" href="${safe}">${safe}</a>`;
-        });
-
         //apply names, colors, ids
-        li.find(".message").html(message);
+        li.find(".message").html(marked.parseInline(message));
 
         if (msg.m === 'dm') {
           if (!gNoChatColors) li.find(".message").css("color", msg.sender.color || "white");


### PR DESCRIPTION
"link formatting" and `url_regex` removed in favor of markdown. The library `marked` handles links itself, so these two things were no longer needed.