### PR TITLE
Fix wrong translation

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -271,7 +271,7 @@ $(function () {
       "New Room...": {
         "pt": "Nova Sala ...",
         "es": "Nueva sala de...",
-        "ru": "Создать комнату...",
+        "ru": "Новая комната...",
         "ja": "新しい部屋",
         "zh": "新房间",
         "nl": "nieuwe Kamer",


### PR DESCRIPTION

"Создать" = "Create", not "New". The word "Новая" would be correct translation. Also, the word "Создать" is too big for a button.

![image](https://user-images.githubusercontent.com/84928386/215354872-6867821e-269b-423d-88aa-cca9fdd8ebf8.png)
![image](https://user-images.githubusercontent.com/84928386/215354853-1c22357e-7562-4047-907d-9121954aae70.png)
